### PR TITLE
Update Manifest.xml

### DIFF
--- a/RePowerReborn/About/Manifest.xml
+++ b/RePowerReborn/About/Manifest.xml
@@ -7,7 +7,7 @@
   </dependencies>
   <incompatibleWith>
     <li>RePower</li>
-    <li>[1.0] RePower</li>
+    <li>[1.0]RePower</li>
   </incompatibleWith>
   <loadAfter>
     <li>HugsLib</li>


### PR DESCRIPTION
By removing the space in the Incompatibilities area of the manifest, it removes the error when using Fluffy's Mod Manager. 